### PR TITLE
Corrected issue in runlengthencoding docstring.  The values and their…

### DIFF
--- a/runlengthencoding/runlengthencoding.py
+++ b/runlengthencoding/runlengthencoding.py
@@ -1,19 +1,19 @@
-"""This module provides a pair of functions for converting lists to and from a
-"run length encoding" format, where successive runs of the same value are
-represented by that value and a count of how many times in a row it should
-appear.
+"""
+Tools for converting lists to and from a "run length encoding" format, where
+successive runs of the same value are represented by:
+    * that value
+    * a count of how many times in a row it should appear.
 
-For example, the list [1, 1, 3, 1] in run-length encoded form is
-[[2, 1], [1, 3], [1, 1]].
+For example, the list
+    [1, 1, 3, 1]
 
-run_length_encode should take a list and produce a run length encoded version
-of that list. run_length_decode should then take a run length encoded list and
-return the original list that would have produced it.
-
+in run-length encoded form is
+    [[1, 2], [3, 1], [1, 1]]
 """
 
 
 def run_length_encode(ls):
+    """Convert list to run-length encoded representation"""
     result = []
     current = [0, 0]
     for value in ls:
@@ -26,6 +26,7 @@ def run_length_encode(ls):
 
 
 def run_length_decode(ls):
+    """Decode run-length encoded list"""
     result = []
     for value, n in ls:
         for _ in range(n):


### PR DESCRIPTION
… run-length had their order swapped in the example, which was quite confusing.  Now corrected, as well as slight neatening of docstring.

I.e. encode([1, 1, 3, 1]) was written as [ [2, 1], [1, 3], [1, 1] ], but it should be [ [1, 2], [3, 1], [1, 1] ].

Thanks!
